### PR TITLE
Removes docs directory when deployment is complete

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ const path = require("path");
 const repository = packageJson["homepage"] || null;
 const rimraf = require("rimraf");
 
+console.time('Deployment Time');
+
 function pushToGhPages() {
     ghpages.publish("docs", {
             "branch": "master",
@@ -23,10 +25,19 @@ function pushToGhPages() {
                 console.log("The build has completed but has not been pushed to github.");
                 return console.error(error);
             }
-            console.log("Finished! production build is ready for gh-pages");
-            console.log("Pushed to gh-pages branch");
+            console.log("The production build is ready and has been pushed to gh-pages branch.");
+            removeDocsDirectory();
         }
     );
+}
+
+function removeDocsDirectory(){
+    rimraf('docs', function(){
+        console.log('________________________________________________________________________________________________________');
+        console.log('Deployment complete. Check Master branch for docs directory.  The local docs directory has been removed.');
+        console.log('‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾');
+        console.timeEnd('Deployment Time');
+    })
 }
 
 function copyFiles(originalFile, newFile, callback) {


### PR DESCRIPTION
Hey I have another PR for you.  When you run the script, the docs directory is no longer needed locally after a successful deploy.  So I wrote a function the removes the local docs directory when the deployment has successfully completed.  I also added some formatting to the console logs including the output of how long it took to deploy.  Take a look and let me know if you would like some modifications or have any objections.  Thanks!