### PR TITLE
Fix #17, check if docs/index doesn't exist and copy to docs dir sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,9 @@ function copyFiles(originalFile, newFile, callback) {
 
 function editForProduction() {
     console.log("Preparing files for github pages");
+    if (!fs.exists("docs/index.html")) {
+        fs.createReadStream("index.html").pipe(fs.createWriteStream("docs/index.html"));
+    } 
     fs.readFile("docs/index.html", "utf-8", function(error, data) {
         if (error) {
             return console.error(error);


### PR DESCRIPTION
I really don't know how the package was working, maybe with other web pack setups de index.html is inside the dist file. The reason why it was failing it's because it tries to read the /docs/index.html file, but that file is never copied from the /index.html (the standard path for all Vue-CLI templates), then I just have to check if the file exists and if not copy sync the file.

Then I notice another error but I'm going to create an issue for that. Please see if this fix works with your test setup, or resolve the other user's problems.
