### PR TITLE
Fix #21

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const ncp = require("ncp").ncp;
 const packageJson = require("../../package.json");
 const path = require("path");
 const repository = packageJson["homepage"] || null;
+const webpackSimpleTemplate = packageJson["wst"] || null;
 const rimraf = require("rimraf");
 
 console.time('Deployment Time');
@@ -59,7 +60,11 @@ function editForProduction() {
             return console.error(error);
         }
         const removeLeadingSlash = data.replace(/(src|href)=\//g, "$1=");
-        fs.writeFileSync("docs/index.html", removeLeadingSlash);
+        let removeWebpackSimpleTemplate = removeLeadingSlash;
+        if (webpackSimpleTemplate) {
+            removeWebpackSimpleTemplate = data.replace(webpackSimpleTemplate, "");
+        } 
+        fs.writeFileSync("docs/index.html", removeWebpackSimpleTemplate);
         if (repository !== null) {
             pushToGhPages();
         }


### PR DESCRIPTION
(Remove old one because was referencing an incorrect issue).

I just create a variable to a property in package.json called wst (webpack simple template), if that variable exists the index.html will be replaced every variable instance for "".

In my case, in webpack simple, the dir reference was build 
`    <script src="/dist/build.js"></script>`
After the change
`<script src="build.js"></script>`